### PR TITLE
Use Public Boojum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ derivative = "2"
 franklin_crypto = {package = "franklin-crypto", features = ["plonk"], git = "https://github.com/matter-labs/franklin-crypto", branch = "snark_wrapper"}
 # franklin_crypto = {package = "franklin-crypto", features = ["plonk"], path = "../franklin-crypto"}
 rescue_poseidon = {git = "https://github.com/matter-labs/rescue-poseidon.git", branch = "poseidon2"}
-boojum = {git = "https://github.com/matter-labs/boojum.git", branch = "main"}
+boojum = {git = "https://github.com/matter-labs/era-boojum.git", branch = "main"}
 
 # rescue_poseidon = {path = "../rescue-poseidon"}
 # boojum = {package = "boojum", path = "../boojum" }


### PR DESCRIPTION
### What

This PR moves the repo to use the public version of boojum as it’s being fully open sourced.