### PR TITLE
verify poseidon2 pow

### DIFF
--- a/src/implementations/poseidon2/mod.rs
+++ b/src/implementations/poseidon2/mod.rs
@@ -17,6 +17,7 @@ use derivative::*;
 
 pub mod transcript;
 pub mod tree_hasher;
+pub mod pow;
 
 #[derive(Derivative)]
 #[derivative(Clone, Debug)]

--- a/src/implementations/poseidon2/pow.rs
+++ b/src/implementations/poseidon2/pow.rs
@@ -1,0 +1,59 @@
+use crate::traits::pow::RecursivePoWRunner;
+
+use super::*;
+use rescue_poseidon::franklin_crypto::bellman::Field;
+
+pub type ConcretePoseidon2SpongeGadget<E> = CircuitPoseidon2Sponge<E, 2, 3, 3, true>;
+
+impl<E: Engine> RecursivePoWRunner<E> for ConcretePoseidon2SpongeGadget<E> {
+    fn verify_from_field_elements<CS: ConstraintSystem<E>>(
+        cs: &mut CS,
+        seed: Vec<GoldilocksField<E>>,
+        pow_challenge_le_bits: [Boolean; 64],
+        pow_bits: usize,
+    ) -> Result<(Boolean, [GoldilocksField<E>; 2]), SynthesisError> {
+        let mut sponge = ConcretePoseidon2SpongeGadget::new();
+
+        for el in seed.iter() {
+            sponge.absorb_single_gl(cs, el)?;
+        }
+
+        // commit nonce
+        let mut lc = LinearCombination::zero();
+        let mut coeff = E::Fr::one();
+        for bit in pow_challenge_le_bits[..32].iter() {
+            lc.add_assign_boolean_with_coeff(bit, coeff.clone());
+            coeff.double();
+        }
+        let low = lc.into_num(cs)?;
+        let low = GoldilocksField::from_num(cs, low)?;
+        sponge.absorb_single_gl(cs, &low)?;
+
+        let mut lc = LinearCombination::zero();
+        let mut coeff = E::Fr::one();
+        for bit in pow_challenge_le_bits[32..].iter() {
+            lc.add_assign_boolean_with_coeff(bit, coeff.clone());
+            coeff.double();
+        }
+        let high = lc.into_num(cs)?;
+        let high = GoldilocksField::from_num(cs, high)?;
+        sponge.absorb_single_gl(cs, &high)?;
+
+        // get final pow challenge
+        let result = sponge.finalize(cs)?[0];
+
+        // verify that  pow challenge has enough zeroes
+        let allocated_bools = result.into_bits_le(cs, None)?;
+
+        let mut lc = LinearCombination::zero();
+        let coeff = E::Fr::one();
+        for b in allocated_bools.iter().take(pow_bits) {
+            lc.add_assign_boolean_with_coeff(b, coeff);
+        }
+        let num_zeroes = lc.into_num(cs)?;
+        let result = num_zeroes.is_zero(cs)?;
+        Boolean::enforce_equal(cs, &result, &Boolean::constant(true))?;
+
+        Ok((result, [low, high]))
+    }
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -9,3 +9,6 @@ use crate::franklin_crypto::bellman::SynthesisError;
 pub mod circuit;
 pub mod transcript;
 pub mod tree_hasher;
+pub mod pow;
+
+pub use pow::*;

--- a/src/traits/pow.rs
+++ b/src/traits/pow.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+pub trait RecursivePoWRunner<E: Engine> {
+    fn verify_from_field_elements<CS: ConstraintSystem<E>>(
+        cs: &mut CS,
+        seed: Vec<GoldilocksField<E>>,
+        pow_challenge: [Boolean; 64],
+        pow_bits: usize,
+    ) -> Result<(Boolean, [GoldilocksField<E>; 2]), SynthesisError>;
+}

--- a/src/verifier/fri.rs
+++ b/src/verifier/fri.rs
@@ -11,6 +11,7 @@ pub(crate) fn verify_fri_part<
         E,
         CircuitCompatibleCap = H::CircuitOutput,
     >,
+    POW: RecursivePoWRunner<E>,
 >(
     cs: &mut CS,
     proof: &AllocatedProof<E, H>,
@@ -37,20 +38,20 @@ pub(crate) fn verify_fri_part<
     transcript.witness_field_elements(cs, &proof.final_fri_monomials[0])?;
     transcript.witness_field_elements(cs, &proof.final_fri_monomials[1])?;
 
-    assert_eq!(constants.new_pow_bits, 0, "PoW not supported yet");
-    // if new_pow_bits != 0 {
-    //     log!("Doing PoW verification for {} bits", new_pow_bits);
-    //     // log!("Prover gave challenge 0x{:016x}", proof.pow_challenge);
-
-    //     // pull enough challenges from the transcript
-    //     let mut num_challenges = 256 / F::CHAR_BITS;
-    //     if num_challenges % F::CHAR_BITS != 0 {
-    //         num_challenges += 1;
-    //     }
-    //     let _challenges: Vec<_> = transcript.get_multiple_challenges(cs, num_challenges);
-
-    //     todo!()
-    // }
+    if constants.new_pow_bits != 0 {
+        // pull enough challenges from the transcript
+        let mut num_challenges = 256 / GL::CHAR_BITS;
+        if num_challenges % GL::CHAR_BITS != 0 {
+            num_challenges += 1;
+        }
+        let challenges: Vec<_> = transcript.get_multiple_challenges(cs, num_challenges as usize)?;                
+        let (is_valid, pow_challenge_limbs) = POW::verify_from_field_elements(cs, challenges, proof.pow_challenge_le, constants.new_pow_bits)?;
+        match is_valid.get_value(){
+            Some(is_valid) => if is_valid == false {println!("PoW challenge is invalid")},
+            None => (),
+        }
+        transcript.witness_field_elements(cs, &pow_challenge_limbs)?;
+    }    
 
     let max_needed_bits = (fixed_parameters.domain_size
         * fixed_parameters.fri_lde_factor as u64)

--- a/src/verifier_structs/allocated_proof.rs
+++ b/src/verifier_structs/allocated_proof.rs
@@ -18,7 +18,7 @@ pub struct AllocatedProof<E: Engine, H: CircuitGLTreeHasher<E>> {
 
     pub queries_per_fri_repetition: Vec<AllocatedSingleRoundQueries<E, H>>,
 
-    pub pow_challenge: [Boolean; 64],
+    pub pow_challenge_le: [Boolean; 64],
 }
 
 impl<
@@ -163,7 +163,7 @@ impl<
 
             queries_per_fri_repetition,
 
-            pow_challenge: pow_challenge_boolean,
+            pow_challenge_le: pow_challenge_boolean,
         })
     }
 }


### PR DESCRIPTION
# What ❔

This PR introduces a new circuit that works with Plonk's naive main gate even without both lookup tables and sbox custom gate. It  also enables PoW verification that is used in  very last step of the proof compression. 

## Why ❔


## Checklist

- [ x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ x] Tests for the changes have been added / updated.
- [ x] Documentation comments have been added / updated.
- [ x] Code has been formatted via `zk fmt` and `zk lint`.
